### PR TITLE
Fix major bug in score calculation

### DIFF
--- a/functions/calculate_player_score.py
+++ b/functions/calculate_player_score.py
@@ -11,10 +11,7 @@ def calculate_player_score(player):
     playername = player["playername"]
     # put in list to make non consumable
     entries = list(entry_repository.get_entries_for_player(playername))
-    print("Entries:")
-    for entry in entries:
-        print(entry)
-    play_points = calculate_play_points(entries, player_id)
+    play_points = calculate_play_points(entries, playername)
     attendance_points = calculate_attendance(entries)
     jank_points = calculate_jank_points(player_id)
     # sum up all totals for overall points gained
@@ -29,25 +26,25 @@ def calculate_player_score(player):
     }
 
 
-def calculate_play_points(entries, player_id):
+def calculate_play_points(entries, playername):
     play_points_total = 0
 
     for entry in entries:
-        player_score, opp_score = determine_match_scores(entry, player_id)
-        print(f"player_score: {player_score}")
-        print(f"opp_score: {opp_score}")
+        score = determine_match_scores(entry, playername)
+        print(f"player_score: {score["player_score"]}")
+        print(f"opp_score: {score["opp_score"]}")
         play_points_total += calculate_match_points(
-            player_score, opp_score
+            score["player_score"], score["opp_score"]
         )
         print(f"play_points_total: {play_points_total}")
 
     return play_points_total
 
 
-def determine_match_scores(entry, player_id):
+def determine_match_scores(entry, playername):
     player_score = 0
     opp_score = 0
-    if entry["player1"] == player_id:
+    if entry["player1"] == playername:
         player_score = entry["score1"]
         opp_score = entry["score2"]
     else:


### PR DESCRIPTION
Comparison of **player_score > opp_score** was doing a lexicographical (alphabetical) comparison of the words **player_score** and **opp_score**. As p is always after o it would always return 3 points.

Additionally calculate_play_points expected the player's ids to be present in the entry, as these are the names instead the determination of which score is the player's and which is the opponent's would always default to the else condition. Now the playername is passed in and the assignment determines the scores for each person correctly.

Attached is the standings from the excel maintained by Carmen which was used to compare the scores against.
![WhatsApp Image 2025-10-01 at 21 19 52_fdeb038e](https://github.com/user-attachments/assets/fce64db0-0809-4a2d-aa38-b1bffc3eb6d7)
